### PR TITLE
Fix panic when use ephemeral devises

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,21 +18,21 @@ install: build
 release: test
 	go get github.com/mitchellh/gox
 	gox --output 'dist/{{.OS}}_{{.Arch}}/{{.Dir}}'
-	zip releases/packer-post-processor-amazon-ami-management_darwin_386.zip    dist/darwin_386/packer-post-processor-amazon-ami-management
-	zip releases/packer-post-processor-amazon-ami-management_darwin_amd64.zip  dist/darwin_amd64/packer-post-processor-amazon-ami-management
-	zip releases/packer-post-processor-amazon-ami-management_freebsd_386.zip   dist/freebsd_386/packer-post-processor-amazon-ami-management
-	zip releases/packer-post-processor-amazon-ami-management_freebsd_amd64.zip dist/freebsd_amd64/packer-post-processor-amazon-ami-management
-	zip releases/packer-post-processor-amazon-ami-management_freebsd_arm.zip   dist/freebsd_arm/packer-post-processor-amazon-ami-management
-	zip releases/packer-post-processor-amazon-ami-management_linux_386.zip     dist/linux_386/packer-post-processor-amazon-ami-management
-	zip releases/packer-post-processor-amazon-ami-management_linux_amd64.zip   dist/linux_amd64/packer-post-processor-amazon-ami-management
-	zip releases/packer-post-processor-amazon-ami-management_linux_arm.zip     dist/linux_arm/packer-post-processor-amazon-ami-management
-	zip releases/packer-post-processor-amazon-ami-management_netbsd_386.zip    dist/netbsd_386/packer-post-processor-amazon-ami-management
-	zip releases/packer-post-processor-amazon-ami-management_netbsd_amd64.zip  dist/netbsd_amd64/packer-post-processor-amazon-ami-management
-	zip releases/packer-post-processor-amazon-ami-management_netbsd_arm.zip    dist/netbsd_arm/packer-post-processor-amazon-ami-management
-	zip releases/packer-post-processor-amazon-ami-management_openbsd_386.zip   dist/openbsd_386/packer-post-processor-amazon-ami-management
-	zip releases/packer-post-processor-amazon-ami-management_openbsd_amd64.zip dist/openbsd_amd64/packer-post-processor-amazon-ami-management
-	zip releases/packer-post-processor-amazon-ami-management_windows_386.zip   dist/windows_386/packer-post-processor-amazon-ami-management.exe
-	zip releases/packer-post-processor-amazon-ami-management_windows_amd64.zip dist/windows_amd64/packer-post-processor-amazon-ami-management.exe
+	zip -j releases/packer-post-processor-amazon-ami-management_darwin_386.zip    dist/darwin_386/packer-post-processor-amazon-ami-management
+	zip -j releases/packer-post-processor-amazon-ami-management_darwin_amd64.zip  dist/darwin_amd64/packer-post-processor-amazon-ami-management
+	zip -j releases/packer-post-processor-amazon-ami-management_freebsd_386.zip   dist/freebsd_386/packer-post-processor-amazon-ami-management
+	zip -j releases/packer-post-processor-amazon-ami-management_freebsd_amd64.zip dist/freebsd_amd64/packer-post-processor-amazon-ami-management
+	zip -j releases/packer-post-processor-amazon-ami-management_freebsd_arm.zip   dist/freebsd_arm/packer-post-processor-amazon-ami-management
+	zip -j releases/packer-post-processor-amazon-ami-management_linux_386.zip     dist/linux_386/packer-post-processor-amazon-ami-management
+	zip -j releases/packer-post-processor-amazon-ami-management_linux_amd64.zip   dist/linux_amd64/packer-post-processor-amazon-ami-management
+	zip -j releases/packer-post-processor-amazon-ami-management_linux_arm.zip     dist/linux_arm/packer-post-processor-amazon-ami-management
+	zip -j releases/packer-post-processor-amazon-ami-management_netbsd_386.zip    dist/netbsd_386/packer-post-processor-amazon-ami-management
+	zip -j releases/packer-post-processor-amazon-ami-management_netbsd_amd64.zip  dist/netbsd_amd64/packer-post-processor-amazon-ami-management
+	zip -j releases/packer-post-processor-amazon-ami-management_netbsd_arm.zip    dist/netbsd_arm/packer-post-processor-amazon-ami-management
+	zip -j releases/packer-post-processor-amazon-ami-management_openbsd_386.zip   dist/openbsd_386/packer-post-processor-amazon-ami-management
+	zip -j releases/packer-post-processor-amazon-ami-management_openbsd_amd64.zip dist/openbsd_amd64/packer-post-processor-amazon-ami-management
+	zip -j releases/packer-post-processor-amazon-ami-management_windows_386.zip   dist/windows_386/packer-post-processor-amazon-ami-management.exe
+	zip -j releases/packer-post-processor-amazon-ami-management_windows_amd64.zip dist/windows_amd64/packer-post-processor-amazon-ami-management.exe
 
 clean:
 	rm -rf dist/

--- a/plugin/post-processor.go
+++ b/plugin/post-processor.go
@@ -107,6 +107,10 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 		// Because it retain snapshots. Following operation is deleting snapshots.
 		log.Printf("Deleting snapshot related to AMI (%s)", *image.ImageId)
 		for _, device := range image.BlockDeviceMappings {
+			// skip delete if use ephemeral devise
+			if device.Ebs == nil {
+				continue
+			}
 			log.Printf("Deleting snapshot (%s) related to AMI (%s)", *device.Ebs.SnapshotId, *image.ImageId)
 			if _, err := ec2conn.DeleteSnapshot(&ec2.DeleteSnapshotInput{
 				SnapshotId: device.Ebs.SnapshotId,

--- a/plugin/post-processor_test.go
+++ b/plugin/post-processor_test.go
@@ -151,3 +151,55 @@ func TestPostProcessor_PostProcess_manyImages(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 }
+
+func TestPostProcessor_PostProcess_ephemeralDevise(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	ec2mock := awsmock.NewMockEC2API(ctrl)
+
+	ec2mock.EXPECT().DescribeImages(&ec2.DescribeImagesInput{
+		Filters: []*ec2.Filter{
+			&ec2.Filter{
+				Name: aws.String("tag:Amazon_AMI_Management_Identifier"),
+				Values: []*string{
+					aws.String("packer-example"),
+				},
+			},
+		},
+	}).Return(&ec2.DescribeImagesOutput{
+		Images: []*ec2.Image{&ec2.Image{
+			ImageId:      aws.String("ami-12345a"),
+			CreationDate: aws.String("2016-08-20T12:19:56.000Z"),
+			BlockDeviceMappings: []*ec2.BlockDeviceMapping{&ec2.BlockDeviceMapping{
+				Ebs: &ec2.EbsBlockDevice{
+					SnapshotId: aws.String("snap-12345a"),
+				},
+			}, &ec2.BlockDeviceMapping{
+				Ebs: nil,
+			}, &ec2.BlockDeviceMapping{
+				Ebs: nil,
+			}},
+		}},
+	}, nil)
+
+	ec2mock.EXPECT().DeregisterImage(&ec2.DeregisterImageInput{
+		ImageId: aws.String("ami-12345a"),
+	}).Return(&ec2.DeregisterImageOutput{}, nil)
+	ec2mock.EXPECT().DeleteSnapshot(&ec2.DeleteSnapshotInput{
+		SnapshotId: aws.String("snap-12345a"),
+	}).Return(&ec2.DeleteSnapshotOutput{}, nil)
+
+	p := PostProcessor{ec2conn: ec2mock}
+	p.config.Identifier = "packer-example"
+	p.config.KeepReleases = 0
+	artifact := &packer.MockArtifact{}
+	_, keep, err := p.PostProcess(testUi(), artifact)
+
+	if !keep {
+		t.Fatal("should keep")
+	}
+
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+}


### PR DESCRIPTION
This post-processor plugin causes panic when use other than Amazon Linux image.

```
$ PACKER_LOG=1 packer build template.json

...

amazon-ebs (amazon-ami-management): Deleting image: ami-xxxxxxx
2016/08/20 12:59:52 ui:     amazon-ebs (amazon-ami-management): Deleting image: ami-xxxxxxx
2016/08/20 12:59:52 packer-post-processor-amazon-ami-management: 2016/08/20 12:59:52 Deleting image AMI (ami-xxxxxxx)
2016/08/20 12:59:52 packer-post-processor-amazon-ami-management: 2016/08/20 12:59:52 Deleting snapshot related to AMI (ami-xxxxxxx)
2016/08/20 12:59:52 packer-post-processor-amazon-ami-management: 2016/08/20 12:59:52 Deleting snapshot (snap-xxxxxxxx) related to AMI (ami-xxxxxxx)
2016/08/20 12:59:53 packer-post-processor-amazon-ami-management: panic:Build 'amazon-ebs' errored: 2 error(s) occurred:

* Post-processor failed: unexpected EOF
* Error destroying builder artifact: reading body [pos 45]: cannot decode non-nil codec value into nil error (1 methods)

==> Some builds didn't complete successfully and had errors:
runtime error: invalid memory address or nil pointer dereference
2016/08/20 12:59:53 packer-post-processor-amazon-ami-management: [signal 0xb code=0x1 addr=0x18 pc=0x4658e6]
2016/08/20 12:59:53 packer-post-processor-amazon-ami-management:
2016/08/20 12:59:53 packer-post-processor-amazon-ami-management: goroutine 34 [running]:
2016/08/20 12:59:53 packer-post-processor-amazon-ami-management: panic(0xb9de80, 0xc82000a0f0)
2016/08/20 12:59:53 packer-post-processor-amazon-ami-management:        /usr/local/Cellar/go/1.6/libexec/src/runtime/panic.go:464 +0x3e6
2016/08/20 12:59:53 packer-post-processor-amazon-ami-management: github.com/wata727/packer-post-processor-amazon-ami-management/plugin.(*PostProcessor).PostProcess(0xc82013e0f0, 0x7fc8e2b837b0$
0xc82013db80, 0x7fc8e2b837f8, 0xc82013dba0, 0x0, 0x0, 0xc81fff32b4, 0x0, 0x0)
2016/08/20 12:59:53 packer-post-processor-amazon-ami-management:        /Users/watanabekazuma/workspace/golang/src/github.com/wata727/packer-post-processor-amazon-ami-management/plugin/post-processor.go:109 +0xe06
2016/08/20 12:59:53 packer-post-processor-amazon-ami-management: github.com/mitchellh/packer/packer/rpc.(*PostProcessorServer).PostProcess(0xc82013cbe0, 0x0, 0xc8201ac490, 0x0, 0x0)
2016/08/20 12:59:53 packer-post-processor-amazon-ami-management:        /Users/watanabekazuma/workspace/golang/src/github.com/mitchellh/packer/packer/rpc/post_processor.go:83 +0x2ed
2016/08/20 12:59:53 packer-post-processor-amazon-ami-management: reflect.Value.call(0xb534c0, 0xbbd748, 0x13, 0xd00cd8, 0x4, 0xc82007bed8, 0x3, 0x3, 0x0, 0x0, ...)
2016/08/20 12:59:53 packer-post-processor-amazon-ami-management:        /usr/local/Cellar/go/1.6/libexec/src/reflect/value.go:435 +0x120d
2016/08/20 12:59:53 packer-post-processor-amazon-ami-management: reflect.Value.Call(0xb534c0, 0xbbd748, 0x13, 0xc82007bed8, 0x3, 0x3, 0x0, 0x0, 0x0)
2016/08/20 12:59:53 packer-post-processor-amazon-ami-management:        /usr/local/Cellar/go/1.6/libexec/src/reflect/value.go:303 +0xb1
2016/08/20 12:59:53 packer-post-processor-amazon-ami-management: net/rpc.(*service).call(0xc820114780, 0xc820114740, 0xc8200ccc90, 0xc820016e80, 0xc82013ce60, 0xa5f040, 0xc8201ac2bc, 0x18a, 0x$16fc0, 0xc8201ac490, ...)
2016/08/20 12:59:53 packer-post-processor-amazon-ami-management:        /usr/local/Cellar/go/1.6/libexec/src/net/rpc/server.go:383 +0x1c2
2016/08/20 12:59:53 packer-post-processor-amazon-ami-management: created by net/rpc.(*Server).ServeCodec
2016/08/20 12:59:53 packer-post-processor-amazon-ami-management:        /usr/local/Cellar/go/1.6/libexec/src/net/rpc/server.go:477 +0x49d
2016/08/20 12:59:53 Deleting original artifact for build 'amazon-ebs'
2016/08/20 12:59:53 packer: 2016/08/20 12:59:53 Deregistering image ID (ami-xxxxxxxx) from region (us-east-1)
2016/08/20 12:59:53 /root/.packer.d/plugins/packer-post-processor-amazon-ami-management: plugin process exited
2016/08/20 12:59:53 ui error: Build 'amazon-ebs' errored: 2 error(s) occurred:

* Post-processor failed: unexpected EOF
* Error destroying builder artifact: reading body [pos 45]: cannot decode non-nil codec value into nil error (1 methods)
2016/08/20 12:59:53 Builds completed. Waiting on interrupt barrier...
2016/08/20 12:59:53 machine readable: error-count []string{"1"}
2016/08/20 12:59:53 ui error:
==> Some builds didn't complete successfully and had errors:
2016/08/20 12:59:53 machine readable: amazon-ebs,error []string{"2 error(s) occurred:\n\n* Post-processor failed: unexpected EOF\n* Error destroying builder artifact: reading body [pos 45]: can
not decode non-nil codec value into nil error (1 methods)"}
2016/08/20 12:59:53 ui error: --> amazon-ebs: 2 error(s) occurred:

* Post-processor failed: unexpected EOF
* Error destroying builder artifact: reading body [pos 45]: cannot decode non-nil codec value into nil error (1 methods)
2016/08/20 12:59:53 ui:
==> Builds finished but no artifacts were created.
2016/08/20 12:59:53 waiting for all plugin processes to complete...
--> amazon-ebs: 2 error(s) occurred:

* Post-processor failed: unexpected EOF
* Error destroying builder artifact: reading body [pos 45]: cannot decode non-nil codec value into nil error (1 methods)

==> Builds finished but no artifacts were created.
2016/08/20 12:59:53 /usr/local/bin/packer: plugin process exited
2016/08/20 12:59:53 /usr/local/bin/packer: plugin process exited
```

I've get the above results when use Ubuntu 14.04 LTS for `source_ami`.
Ubuntu 14.04 image outputs from AWS are following: (Thanks for [k0kubun/pp](https://github.com/k0kubun/pp))

```
&ec2.Image{
  _:                   struct {}{},
  Architecture:        &"x86_64",
  BlockDeviceMappings: []*ec2.BlockDeviceMapping{
    &ec2.BlockDeviceMapping{
      _:          struct {}{},
      DeviceName: &"/dev/sda1",
      Ebs:        &ec2.EbsBlockDevice{
        _:                   struct {}{},
        DeleteOnTermination: &true,
        Encrypted:           &false,
        Iops:                (*int64)(nil),
        SnapshotId:          &"snap-xxxxxxxx",
        VolumeSize:          &8,
        VolumeType:          &"gp2",
      },
      NoDevice:    (*string)(nil),
      VirtualName: (*string)(nil),
    },
    &ec2.BlockDeviceMapping{
      _:           struct {}{},
      DeviceName:  &"/dev/sdb",
      Ebs:         (*ec2.EbsBlockDevice)(nil),
      NoDevice:    (*string)(nil),
      VirtualName: &"ephemeral0",
    },
    &ec2.BlockDeviceMapping{
      _:           struct {}{},
      DeviceName:  &"/dev/sdc",
      Ebs:         (*ec2.EbsBlockDevice)(nil),
      NoDevice:    (*string)(nil),
      VirtualName: &"ephemeral1",
    },
  },
  CreationDate:    &"2016-08-20T13:05:10.000Z",
  Description:     (*string)(nil),
  Hypervisor:      &"xen",
  ImageId:         &"ami-xxxxxxxx",
  ImageLocation:   &"hogehoge/packer-example 1471698196",
  ImageOwnerAlias: (*string)(nil),
  ImageType:       &"machine",
  KernelId:        (*string)(nil),
  Name:            &"packer-example 1471698196",
  OwnerId:         &"hogehoge",
  Platform:        (*string)(nil),
  ProductCodes:    []*ec2.ProductCode{},
  Public:          &false,
  RamdiskId:       (*string)(nil),
  RootDeviceName:  &"/dev/sda1",
  RootDeviceType:  &"ebs",
  SriovNetSupport: &"simple",
  State:           &"available",
  StateReason:     (*ec2.StateReason)(nil),
  Tags:            []*ec2.Tag{
    &ec2.Tag{
      _:     struct {}{},
      Key:   &"Amazon_AMI_Management_Identifier",
      Value: &"packer-example",
    },
  },
  VirtualizationType: &"hvm",
}%
```

This image has ephemeral disks. Ephemeral disk has `Ebs` attributes, but NOT has `SnapshotId`.
If delete snapshots, should check whether `Ebs` is nil at first.