### PR TITLE
Revert "Inherit from Packer access config"

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -276,6 +276,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "39b23253d229ecca7212589915023fe83994687c762593d9783f535d4490660a"
+  inputs-digest = "a1b761b6ecb5086ab45e7081787139e04f78bf191954f1b8ea8e98d84ad68ae2"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The following example `template.json`:
   }],
   "post-processors":[{
     "type": "amazon-ami-management",
+    "region": "us-east-1",
     "identifier": "packer-example",
     "keep_releases": "3"
   }]
@@ -55,6 +56,12 @@ Required:
     - The Identifier of AMIs. This plugin looks `Amazon_AMI_Management_Identifier` tag. If `identifier` matches tag value, these AMI becomes to management target.
   - `keep_releases` (interger)
     - The number of AMIs.
+  - `access_key` (string)
+    - The access key used in AWS. If you can use environment values or [shared credentials](https://blogs.aws.amazon.com/security/post/Tx3D6U6WSFGOK2H/A-New-and-Standardized-Way-to-Manage-Credentials-in-the-AWS-SDKs), not required this parameter.
+  - `secret_key` (string)
+    - The secret key used in AWS. If you can use environment values or [shared credentials](https://blogs.aws.amazon.com/security/post/Tx3D6U6WSFGOK2H/A-New-and-Standardized-Way-to-Manage-Credentials-in-the-AWS-SDKs), not required this parameter.
+  - `region` (string)
+    - The name of the region, such as `us-east-1` in which to manage AMIs. If you can use environment values, not required this parameter.
 
 ## Developing Plugin
 

--- a/post-processor.go
+++ b/post-processor.go
@@ -7,6 +7,10 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	awscommon "github.com/hashicorp/packer/builder/amazon/common"
@@ -24,6 +28,9 @@ type Config struct {
 
 	Identifier   string `mapstructure:"identifier"`
 	KeepReleases int    `mapstructure:"keep_releases"`
+	AccessKey    string `mapstructure:"access_key"`
+	SecretKey    string `mapstructure:"secret_key"`
+	Region       string `mapstructure:"region"`
 
 	ctx interpolate.Context
 }
@@ -49,12 +56,6 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 		return err
 	}
 
-	session, err := p.config.AccessConfig.Session()
-	if err != nil {
-		return err
-	}
-	p.ec2conn = ec2.New(session)
-
 	return nil
 }
 
@@ -62,8 +63,30 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (packer.Artifact, bool, error) {
 	log.Println("Running the post-processor")
 
+	ec2conn := p.ec2conn
+	if ec2conn == nil {
+		// If processor doesn't set connection, make the real connection
+		config := aws.NewConfig().WithRegion(p.config.Region).WithMaxRetries(11)
+		sess := session.New(config)
+		creds := credentials.NewChainCredentials([]credentials.Provider{
+			&credentials.StaticProvider{Value: credentials.Value{
+				AccessKeyID:     p.config.AccessKey,
+				SecretAccessKey: p.config.SecretKey,
+			}},
+			&credentials.EnvProvider{},
+			&credentials.SharedCredentialsProvider{Filename: "", Profile: ""},
+			&ec2rolecreds.EC2RoleProvider{
+				Client: ec2metadata.New(sess),
+			},
+		})
+
+		log.Println("Creating a session")
+		ec2Session := session.New(config.WithCredentials(creds))
+		ec2conn = ec2.New(ec2Session)
+	}
+
 	log.Println("Describing images")
-	output, err := p.ec2conn.DescribeImages(&ec2.DescribeImagesInput{
+	output, err := ec2conn.DescribeImages(&ec2.DescribeImagesInput{
 		Filters: []*ec2.Filter{
 			{
 				Name: aws.String("tag:Amazon_AMI_Management_Identifier"),
@@ -91,7 +114,7 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 		}
 		ui.Message(fmt.Sprintf("Deleting image: %s", *image.ImageId))
 		log.Printf("Deleting AMI (%s)", *image.ImageId)
-		if _, err := p.ec2conn.DeregisterImage(&ec2.DeregisterImageInput{
+		if _, err := ec2conn.DeregisterImage(&ec2.DeregisterImageInput{
 			ImageId: image.ImageId,
 		}); err != nil {
 			return nil, true, err
@@ -106,7 +129,7 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 				continue
 			}
 			log.Printf("Deleting snapshot (%s) related to AMI (%s)", *device.Ebs.SnapshotId, *image.ImageId)
-			if _, err := p.ec2conn.DeleteSnapshot(&ec2.DeleteSnapshotInput{
+			if _, err := ec2conn.DeleteSnapshot(&ec2.DeleteSnapshotInput{
 				SnapshotId: device.Ebs.SnapshotId,
 			}); err != nil {
 				return nil, true, err


### PR DESCRIPTION
Reverts wata727/packer-post-processor-amazon-ami-management#12

When using `ami_regions`, `AccessConfig.Session()` returns session with copied region (not builder region) :(