### PR TITLE
Support multiple regions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ The following example `template.json`:
     "type": "amazon-ami-management",
     "region": "us-east-1",
     "identifier": "packer-example",
-    "keep_releases": "3"
+    "keep_releases": "3",
+    "ami_regions": ["ap-northeast-1"]
   }]
 }
 ```
@@ -52,8 +53,8 @@ The following example `template.json`:
 Type: `amazon-ami-management`
 
 Required:
-  - `identifier` (string) 
-    - The Identifier of AMIs. This plugin looks `Amazon_AMI_Management_Identifier` tag. If `identifier` matches tag value, these AMI becomes to management target.
+  - `identifier` (string)
+    - An identifier of AMIs. This plugin looks `Amazon_AMI_Management_Identifier` tag. If `identifier` matches tag value, these AMI becomes to management target.
   - `keep_releases` (interger)
     - The number of AMIs.
   - `access_key` (string)
@@ -62,6 +63,10 @@ Required:
     - The secret key used in AWS. If you can use environment values or [shared credentials](https://blogs.aws.amazon.com/security/post/Tx3D6U6WSFGOK2H/A-New-and-Standardized-Way-to-Manage-Credentials-in-the-AWS-SDKs), not required this parameter.
   - `region` (string)
     - The name of the region, such as `us-east-1` in which to manage AMIs. If you can use environment values, not required this parameter.
+
+Optional:
+  - `ami_regions` (array of strings)
+    - A list of regions where copied AMI is located. It is useful when specifying `ami_regions` in builder config.
 
 ## Developing Plugin
 

--- a/post-processor.go
+++ b/post-processor.go
@@ -71,6 +71,11 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 	}
 
 	for _, region := range p.config.AMIRegions {
+		if region == p.config.Region {
+			ui.Message(fmt.Sprintf("Avoiding processing in duplicate region: %s", region))
+			continue
+		}
+
 		ui.Message(fmt.Sprintf("Processing in %s", region))
 		p.makeConnection(region)
 		if err := p.manageAMIs(ui); err != nil {

--- a/post-processor.go
+++ b/post-processor.go
@@ -26,11 +26,12 @@ type Config struct {
 	common.PackerConfig    `mapstructure:",squash"`
 	awscommon.AccessConfig `mapstructure:",squash"`
 
-	Identifier   string `mapstructure:"identifier"`
-	KeepReleases int    `mapstructure:"keep_releases"`
-	AccessKey    string `mapstructure:"access_key"`
-	SecretKey    string `mapstructure:"secret_key"`
-	Region       string `mapstructure:"region"`
+	Identifier   string   `mapstructure:"identifier"`
+	KeepReleases int      `mapstructure:"keep_releases"`
+	AccessKey    string   `mapstructure:"access_key"`
+	SecretKey    string   `mapstructure:"secret_key"`
+	Region       string   `mapstructure:"region"`
+	AMIRegions   []string `mapstructure:"ami_regions"`
 
 	ctx interpolate.Context
 }
@@ -56,6 +57,8 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 		return err
 	}
 
+	p.makeConnection(p.config.Region)
+
 	return nil
 }
 
@@ -63,30 +66,42 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (packer.Artifact, bool, error) {
 	log.Println("Running the post-processor")
 
-	ec2conn := p.ec2conn
-	if ec2conn == nil {
-		// If processor doesn't set connection, make the real connection
-		config := aws.NewConfig().WithRegion(p.config.Region).WithMaxRetries(11)
-		sess := session.New(config)
-		creds := credentials.NewChainCredentials([]credentials.Provider{
-			&credentials.StaticProvider{Value: credentials.Value{
-				AccessKeyID:     p.config.AccessKey,
-				SecretAccessKey: p.config.SecretKey,
-			}},
-			&credentials.EnvProvider{},
-			&credentials.SharedCredentialsProvider{Filename: "", Profile: ""},
-			&ec2rolecreds.EC2RoleProvider{
-				Client: ec2metadata.New(sess),
-			},
-		})
-
-		log.Println("Creating a session")
-		ec2Session := session.New(config.WithCredentials(creds))
-		ec2conn = ec2.New(ec2Session)
+	if err := p.manageAMIs(ui); err != nil {
+		return nil, true, err
 	}
 
+	for _, region := range p.config.AMIRegions {
+		ui.Message(fmt.Sprintf("Processing in %s", region))
+		p.makeConnection(region)
+		if err := p.manageAMIs(ui); err != nil {
+			return nil, true, err
+		}
+	}
+
+	return artifact, true, nil
+}
+
+func (p *PostProcessor) makeConnection(region string) {
+	config := aws.NewConfig().WithRegion(region).WithMaxRetries(11)
+	sess := session.New(config)
+	creds := credentials.NewChainCredentials([]credentials.Provider{
+		&credentials.StaticProvider{Value: credentials.Value{
+			AccessKeyID:     p.config.AccessKey,
+			SecretAccessKey: p.config.SecretKey,
+		}},
+		&credentials.EnvProvider{},
+		&credentials.SharedCredentialsProvider{Filename: "", Profile: ""},
+		&ec2rolecreds.EC2RoleProvider{
+			Client: ec2metadata.New(sess),
+		},
+	})
+
+	p.ec2conn = ec2.New(session.New(config.WithCredentials(creds)))
+}
+
+func (p *PostProcessor) manageAMIs(ui packer.Ui) error {
 	log.Println("Describing images")
-	output, err := ec2conn.DescribeImages(&ec2.DescribeImagesInput{
+	output, err := p.ec2conn.DescribeImages(&ec2.DescribeImagesInput{
 		Filters: []*ec2.Filter{
 			{
 				Name: aws.String("tag:Amazon_AMI_Management_Identifier"),
@@ -97,7 +112,7 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 		},
 	})
 	if err != nil {
-		return nil, true, err
+		return err
 	}
 
 	// Sort in descending order by creation date
@@ -114,10 +129,10 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 		}
 		ui.Message(fmt.Sprintf("Deleting image: %s", *image.ImageId))
 		log.Printf("Deleting AMI (%s)", *image.ImageId)
-		if _, err := ec2conn.DeregisterImage(&ec2.DeregisterImageInput{
+		if _, err := p.ec2conn.DeregisterImage(&ec2.DeregisterImageInput{
 			ImageId: image.ImageId,
 		}); err != nil {
-			return nil, true, err
+			return err
 		}
 
 		// DeregisterImage method only performs to AMI
@@ -129,13 +144,13 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 				continue
 			}
 			log.Printf("Deleting snapshot (%s) related to AMI (%s)", *device.Ebs.SnapshotId, *image.ImageId)
-			if _, err := ec2conn.DeleteSnapshot(&ec2.DeleteSnapshotInput{
+			if _, err := p.ec2conn.DeleteSnapshot(&ec2.DeleteSnapshotInput{
 				SnapshotId: device.Ebs.SnapshotId,
 			}); err != nil {
-				return nil, true, err
+				return err
 			}
 		}
 	}
 
-	return artifact, true, nil
+	return nil
 }


### PR DESCRIPTION
Fixes #7 

Template example:

```json
{
  "builders": [
    {
      "type": "amazon-ebs",
      "region": "us-east-1",
      "source_ami": "ami-6869aa05",
      "instance_type": "t2.micro",
      "ssh_username": "ec2-user",
      "ssh_pty": "true",
      "ami_name": "packer-example {{timestamp}}",
      "ami_regions": ["ap-northeast-1"],
      "tags": {
        "Amazon_AMI_Management_Identifier": "packer-example"
      }
    }
  ],
  "provisioners":[{
    "type": "shell",
    "inline": [
      "echo 'running...'"
    ]
  }],
  "post-processors":[{
    "type": "amazon-ami-management",
    "region": "us-east-1",
    "identifier": "packer-example",
    "keep_releases": "3",
    "ami_regions": ["ap-northeast-1"]
  }]
}
```

Output example:

```
==> amazon-ebs: Running post-processor: amazon-ami-management
    amazon-ebs (amazon-ami-management): Deleting image: ami-1234abcd
    amazon-ebs (amazon-ami-management): Processing in ap-northeast-1
    amazon-ebs (amazon-ami-management): Deleting image: ami-abcd1234
Build 'amazon-ebs' finished.

==> Builds finished. The artifacts of successful builds are:
--> amazon-ebs: AMIs were created:
ap-northeast-1: ami-2345abcd
us-east-1: ami-abcf2345

--> amazon-ebs:
```

cc @0xtf WDYT?