### PR TITLE
Inherit from Packer access config

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -276,6 +276,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "a1b761b6ecb5086ab45e7081787139e04f78bf191954f1b8ea8e98d84ad68ae2"
+  inputs-digest = "39b23253d229ecca7212589915023fe83994687c762593d9783f535d4490660a"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 Packer post-processor plugin for AMI management
 
 ## Description
-This post-processor assists your AMI management. It deletes old AMI and EBS snapshot after bake new AMI.
+This post-processor assists your AMI management. It deletes old AMI and EBS snapshot using `amazon-ebs` builder's access configuration after bake new AMI.
 
 ## Installation
 Packer supports plugin system. Please read the following documentation:
@@ -40,10 +40,9 @@ The following example `template.json`:
   }],
   "post-processors":[{
     "type": "amazon-ami-management",
-    "region": "us-east-1",
+    "regions": ["us-east-1"],
     "identifier": "packer-example",
-    "keep_releases": "3",
-    "ami_regions": ["ap-northeast-1"]
+    "keep_releases": "3"
   }]
 }
 ```
@@ -57,16 +56,8 @@ Required:
     - An identifier of AMIs. This plugin looks `Amazon_AMI_Management_Identifier` tag. If `identifier` matches tag value, these AMI becomes to management target.
   - `keep_releases` (interger)
     - The number of AMIs.
-  - `access_key` (string)
-    - The access key used in AWS. If you can use environment values or [shared credentials](https://blogs.aws.amazon.com/security/post/Tx3D6U6WSFGOK2H/A-New-and-Standardized-Way-to-Manage-Credentials-in-the-AWS-SDKs), not required this parameter.
-  - `secret_key` (string)
-    - The secret key used in AWS. If you can use environment values or [shared credentials](https://blogs.aws.amazon.com/security/post/Tx3D6U6WSFGOK2H/A-New-and-Standardized-Way-to-Manage-Credentials-in-the-AWS-SDKs), not required this parameter.
-  - `region` (string)
-    - The name of the region, such as `us-east-1` in which to manage AMIs. If you can use environment values, not required this parameter.
-
-Optional:
-  - `ami_regions` (array of strings)
-    - A list of regions where copied AMI is located. It is useful when specifying `ami_regions` in builder config.
+  - `regions` (array of strings)
+    - A list of regions, such as `us-east-1` in which to manage AMIs.
 
 ## Developing Plugin
 

--- a/post-processor_test.go
+++ b/post-processor_test.go
@@ -41,8 +41,12 @@ func TestPostProcessor_PostProcess_emptyImages(t *testing.T) {
 		Images: []*ec2.Image{},
 	}, nil)
 
-	p := PostProcessor{ec2conn: ec2mock}
+	p := PostProcessor{
+		testMode: true,
+		ec2conn:  ec2mock,
+	}
 	p.config.Identifier = "packer-example"
+	p.config.Regions = []string{"us-east-1"}
 	artifact := &packer.MockArtifact{}
 	_, keep, err := p.PostProcess(testUI(), artifact)
 
@@ -77,9 +81,13 @@ func TestPostProcessor_PostProcess_fewImages(t *testing.T) {
 		}},
 	}, nil)
 
-	p := PostProcessor{ec2conn: ec2mock}
+	p := PostProcessor{
+		testMode: true,
+		ec2conn:  ec2mock,
+	}
 	p.config.Identifier = "packer-example"
 	p.config.KeepReleases = 3
+	p.config.Regions = []string{"us-east-1"}
 	artifact := &packer.MockArtifact{}
 	_, keep, err := p.PostProcess(testUI(), artifact)
 
@@ -138,9 +146,13 @@ func TestPostProcessor_PostProcess_manyImages(t *testing.T) {
 		SnapshotId: aws.String("snap-12345b"),
 	}).Return(&ec2.DeleteSnapshotOutput{}, nil)
 
-	p := PostProcessor{ec2conn: ec2mock}
+	p := PostProcessor{
+		testMode: true,
+		ec2conn:  ec2mock,
+	}
 	p.config.Identifier = "packer-example"
 	p.config.KeepReleases = 2
+	p.config.Regions = []string{"us-east-1"}
 	artifact := &packer.MockArtifact{}
 	_, keep, err := p.PostProcess(testUI(), artifact)
 
@@ -190,9 +202,13 @@ func TestPostProcessor_PostProcess_ephemeralDevise(t *testing.T) {
 		SnapshotId: aws.String("snap-12345a"),
 	}).Return(&ec2.DeleteSnapshotOutput{}, nil)
 
-	p := PostProcessor{ec2conn: ec2mock}
+	p := PostProcessor{
+		testMode: true,
+		ec2conn:  ec2mock,
+	}
 	p.config.Identifier = "packer-example"
 	p.config.KeepReleases = 0
+	p.config.Regions = []string{"us-east-1"}
 	artifact := &packer.MockArtifact{}
 	_, keep, err := p.PostProcess(testUI(), artifact)
 


### PR DESCRIPTION
Fixes #6 #17 
See also #12 

These changes allow inheriting Packer access config because of removing redundant access config definition.

In the past, these changes were reverted, but solving this problem by setting a region each time.

## Breaking Changes

With these changes, this plugin will not accept `access_key`, `secret_key`, `region` and `ami_regions`. It is necessary to rewrite as follows.

### Before
```json
"post-processors":[{
  "type": "amazon-ami-management",
  "access_key": "AWS_ACCESS_KEY_ID",
  "secret_key": "AWS_SECRET_ACCESS_KEY",
  "region": "us-east-1",
  "identifier": "packer-example",
  "keep_releases": "1",
  "ami_regions": ["us-east-1", "ap-northeast-1"]
}]
```

### After
```json
"post-processors":[{
  "type": "amazon-ami-management",
  "regions": ["us-east-1", "ap-northeast-1"],
  "identifier": "packer-example",
  "keep_releases": "1"
}]
```