### PR TITLE
Validate post-processor's configuration

### DIFF
--- a/post-processor.go
+++ b/post-processor.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"sort"
@@ -49,6 +50,16 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 	}, raws...)
 	if err != nil {
 		return err
+	}
+
+	if p.config.Identifier == "" {
+		return errors.New("empty `identifier` is not allowed. Please make sure that it is set correctly")
+	}
+	if p.config.KeepReleases < 1 {
+		return errors.New("`keep_releases` must be greater than 1. Please make sure that it is set correctly")
+	}
+	if len(p.config.Regions) == 0 {
+		return errors.New("empty `regions` is not allowed. Please make sure that it is set correctly")
 	}
 
 	return nil

--- a/post-processor_test.go
+++ b/post-processor_test.go
@@ -23,6 +23,67 @@ func TestPostProcessor_ImplementsPostProcessor(t *testing.T) {
 	var _ packer.PostProcessor = new(PostProcessor)
 }
 
+func TestPostProcessor_Configure_validConfig(t *testing.T) {
+	p := new(PostProcessor)
+	err := p.Configure(map[string]interface{}{
+		"regions":       []string{"us-east-1"},
+		"identifier":    "packer-example",
+		"keep_releases": 3,
+	})
+
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+}
+
+func TestPostProcessor_Configure_missingRegions(t *testing.T) {
+	p := new(PostProcessor)
+	err := p.Configure(map[string]interface{}{
+		"region":        "us-east-1",
+		"identifier":    "packer-example",
+		"keep_releases": 3,
+	})
+
+	if err == nil {
+		t.Fatal("should cause validation errors")
+	}
+	if err.Error() != "empty `regions` is not allowed. Please make sure that it is set correctly" {
+		t.Fatalf("Unexpected error occurred: %s", err)
+	}
+}
+
+func TestPostProcessor_Configure_emptyIdentifier(t *testing.T) {
+	p := new(PostProcessor)
+	err := p.Configure(map[string]interface{}{
+		"regions":       []string{"us-east-1"},
+		"identifier":    "",
+		"keep_releases": 3,
+	})
+
+	if err == nil {
+		t.Fatal("should cause validation errors")
+	}
+	if err.Error() != "empty `identifier` is not allowed. Please make sure that it is set correctly" {
+		t.Fatalf("Unexpected error occurred: %s", err)
+	}
+}
+
+func TestPostProcessor_Configure_invalidKeepReleases(t *testing.T) {
+	p := new(PostProcessor)
+	err := p.Configure(map[string]interface{}{
+		"regions":       []string{"us-east-1"},
+		"identifier":    "packer-example",
+		"keep_releases": -1,
+	})
+
+	if err == nil {
+		t.Fatal("should cause validation errors")
+	}
+	if err.Error() != "`keep_releases` must be greater than 1. Please make sure that it is set correctly" {
+		t.Fatalf("Unexpected error occurred: %s", err)
+	}
+}
+
 func TestPostProcessor_PostProcess_emptyImages(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()


### PR DESCRIPTION
Fixes #19 

If using a template with invalid post-processor's configuration, Packer outputs error messages and stop building like the following:

```
$ packer build template.json
amazon-ebs output will be in this color.

empty `regions` is not allowed. Please make sure that it is set correctly.
```

This validation checks empty `regions`, empty `identifier` and invalid `keep_releases` (e.g. -1, 0)