### PR TITLE
Update README for AWS configuration attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,17 @@ Required:
 Optional:
   - `dry_run` (boolean) - If `true`, the post-processor doesn't actually delete AMIs.
 
+The following attibutes are also available. These are optional and used in the same way as AWS Builder:
+
+- `access_key`
+- `secret_key`
+- `profile`
+- `token`
+- `mfa_code`
+- `custom_endpoint_ec2`
+- `skip_region_validation`
+- `skip_metadata_api_check`
+
 ### IAM Task or Instance Role
 
 The post-processor requires additional permissions to work. Below is the difference from [the minimum permissions required by Packer](https://www.packer.io/docs/builders/amazon.html#iam-task-or-instance-role).


### PR DESCRIPTION
Fixes #41 

I was completely misunderstood about credentials. When using static credentials, it is necessary to set the access key and secret key separately from the builder configurations.

Fortunately, the current implementation accepts basic AWS attributes, so this pull request only updates the documentation about it.