### PR TITLE
Retry GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: Release
+
+on:
+  push:
+    branches:
+    - '!*'
+    tags:
+    - v*.*.*
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@master
+    - name: Set up Go
+      uses: actions/setup-go@v1
+      with:
+        version: 1.13
+    - name: Run GoReleaser
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        VERSION: v0.116.0
+      run: curl -sL https://git.io/goreleaser | bash

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,5 @@
 env:
-  - GO111MODULE=on
+  - CGO_ENABLED=0
 before:
   hooks:
     - go mod download
@@ -15,11 +15,11 @@ builds:
       - 386
       - amd64
       - arm
-archive:
-  format: zip
-  files:
-    - LICENSE
-    - NOTICE.md
+archives:
+  - id: zip
+    format: zip
+    files:
+      - LICENSE
 changelog:
   skip: true
 checksum:


### PR DESCRIPTION
See also https://github.com/wata727/packer-post-processor-amazon-ami-management/pull/48

When running goreleaser using `docker://goreleaser/goreleaser`, there was a problem that the binary for Linux was broken.

We can build a valid binary by installing and running goreleaser directly on the default image 🎉 