### PR TITLE
Remove the AWS builder dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,4 @@ install: build
 	mkdir -p ~/.packer.d/plugins
 	install ./packer-post-processor-amazon-ami-management ~/.packer.d/plugins/
 
-mock:
-	go generate ./...
-
 .PHONY: default test build install

--- a/access_config.go
+++ b/access_config.go
@@ -1,0 +1,133 @@
+// @see https://github.com/hashicorp/packer/blob/v1.6.4/builder/amazon/common/access_config.go
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	awsCredentials "github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	awsbase "github.com/hashicorp/aws-sdk-go-base"
+	"github.com/hashicorp/go-cleanhttp"
+)
+
+// AccessConfig is for common configuration related to AWS access
+type AccessConfig struct {
+	AccessKey            string `mapstructure:"access_key"`
+	SecretKey            string `mapstructure:"secret_key"`
+	ProfileName          string `mapstructure:"profile"`
+	Token                string `mapstructure:"token"`
+	MFACode              string `mapstructure:"mfa_code"`
+	CustomEndpointEc2    string `mapstructure:"custom_endpoint_ec2"`
+	SkipValidation       bool   `mapstructure:"skip_region_validation"`
+	SkipMetadataAPICheck bool   `mapstructure:"skip_metadata_api_check"`
+
+	session *session.Session
+}
+
+// Session returns a valid session.Session object for access to AWS services, or
+// an error if the authentication and region couldn't be resolved
+func (c *AccessConfig) Session() (*session.Session, error) {
+	if c.session != nil {
+		return c.session, nil
+	}
+
+	// Create new AWS config
+	config := aws.NewConfig().WithCredentialsChainVerboseErrors(true)
+
+	if c.CustomEndpointEc2 != "" {
+		config = config.WithEndpoint(c.CustomEndpointEc2)
+	}
+
+	config = config.WithHTTPClient(cleanhttp.DefaultClient())
+	transport := config.HTTPClient.Transport.(*http.Transport)
+	transport.Proxy = http.ProxyFromEnvironment
+
+	// Figure out which possible credential providers are valid; test that we
+	// can get credentials via the selected providers, and set the providers in
+	// the config.
+	creds, err := c.GetCredentials(config)
+	if err != nil {
+		return nil, err
+	}
+	config.WithCredentials(creds)
+
+	// Create session options based on our AWS config
+	opts := session.Options{
+		SharedConfigState: session.SharedConfigEnable,
+		Config:            *config,
+	}
+
+	if c.ProfileName != "" {
+		opts.Profile = c.ProfileName
+	}
+
+	if c.MFACode != "" {
+		opts.AssumeRoleTokenProvider = func() (string, error) {
+			return c.MFACode, nil
+		}
+	}
+
+	sess, err := session.NewSessionWithOptions(opts)
+	if err != nil {
+		return nil, err
+	}
+	log.Printf("Found region %s", *sess.Config.Region)
+	c.session = sess
+
+	cp, err := c.session.Config.Credentials.Get()
+
+	if IsAWSErr(err, "NoCredentialProviders", "") {
+		return nil, c.NewNoValidCredentialSourcesError(err)
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("Error loading credentials for AWS Provider: %s", err)
+	}
+
+	log.Printf("[INFO] AWS Auth provider used: %q", cp.ProviderName)
+
+	return c.session, nil
+}
+
+// GetCredentials gets credentials from the environment, shared credentials,
+// the session (which may include a credential process), or ECS/EC2 metadata
+// endpoints. GetCredentials also validates the credentials and the ability to
+// assume a role or will return an error if unsuccessful.
+func (c *AccessConfig) GetCredentials(config *aws.Config) (*awsCredentials.Credentials, error) {
+	// Reload values into the config used by the Packer-Terraform shared SDK
+	awsbaseConfig := &awsbase.Config{
+		AccessKey:            c.AccessKey,
+		DebugLogging:         false,
+		Profile:              c.ProfileName,
+		SecretKey:            c.SecretKey,
+		SkipMetadataApiCheck: c.SkipMetadataAPICheck,
+		Token:                c.Token,
+	}
+
+	return awsbase.GetCredentials(awsbaseConfig)
+}
+
+// IsAWSErr returns true if the error matches all these conditions:
+//  * err is of type awserr.Error
+//  * Error.Code() matches code
+//  * Error.Message() contains message
+func IsAWSErr(err error, code string, message string) bool {
+	if err, ok := err.(awserr.Error); ok {
+		return err.Code() == code && strings.Contains(err.Message(), message)
+	}
+	return false
+}
+
+// NewNoValidCredentialSourcesError returns user-friendly errors for authentication failed.
+func (c *AccessConfig) NewNoValidCredentialSourcesError(err error) error {
+	return fmt.Errorf("No valid credential sources found for amazon-ami-management post processor. "+
+		"Please see https://github.com/wata727/packer-post-processor-amazon-ami-management "+
+		"for more information on providing credentials for the post processor. "+
+		"Error: %w", err)
+}

--- a/config.go
+++ b/config.go
@@ -3,7 +3,6 @@
 package main
 
 import (
-	awscommon "github.com/hashicorp/packer/builder/amazon/common"
 	"github.com/hashicorp/packer/common"
 	"github.com/hashicorp/packer/template/interpolate"
 )
@@ -11,8 +10,8 @@ import (
 // Config is a post-processor's configuration
 // PostProcessor generates it using Packer's configuration in `Configure()` method
 type Config struct {
-	common.PackerConfig    `mapstructure:",squash"`
-	awscommon.AccessConfig `mapstructure:",squash"`
+	common.PackerConfig `mapstructure:",squash"`
+	AccessConfig        `mapstructure:",squash"`
 
 	Identifier   string   `mapstructure:"identifier"`
 	KeepReleases int      `mapstructure:"keep_releases"`

--- a/config.hcl2spec.go
+++ b/config.hcl2spec.go
@@ -3,42 +3,32 @@ package main
 
 import (
 	"github.com/hashicorp/hcl/v2/hcldec"
-	"github.com/hashicorp/packer/builder/amazon/common"
 	"github.com/zclconf/go-cty/cty"
 )
 
 // FlatConfig is an auto-generated flat version of Config.
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatConfig struct {
-	PackerBuildName       *string                           `mapstructure:"packer_build_name" cty:"packer_build_name"`
-	PackerBuilderType     *string                           `mapstructure:"packer_builder_type" cty:"packer_builder_type"`
-	PackerDebug           *bool                             `mapstructure:"packer_debug" cty:"packer_debug"`
-	PackerForce           *bool                             `mapstructure:"packer_force" cty:"packer_force"`
-	PackerOnError         *string                           `mapstructure:"packer_on_error" cty:"packer_on_error"`
-	PackerUserVars        map[string]string                 `mapstructure:"packer_user_variables" cty:"packer_user_variables"`
-	PackerSensitiveVars   []string                          `mapstructure:"packer_sensitive_variables" cty:"packer_sensitive_variables"`
-	AccessKey             *string                           `mapstructure:"access_key" required:"true" cty:"access_key"`
-	AssumeRole            *common.FlatAssumeRoleConfig      `mapstructure:"assume_role" required:"false" cty:"assume_role"`
-	CustomEndpointEc2     *string                           `mapstructure:"custom_endpoint_ec2" required:"false" cty:"custom_endpoint_ec2"`
-	CredsFilename         *string                           `mapstructure:"shared_credentials_file" required:"false" cty:"shared_credentials_file"`
-	DecodeAuthZMessages   *bool                             `mapstructure:"decode_authorization_messages" required:"false" cty:"decode_authorization_messages"`
-	InsecureSkipTLSVerify *bool                             `mapstructure:"insecure_skip_tls_verify" required:"false" cty:"insecure_skip_tls_verify"`
-	MaxRetries            *int                              `mapstructure:"max_retries" required:"false" cty:"max_retries"`
-	MFACode               *string                           `mapstructure:"mfa_code" required:"false" cty:"mfa_code"`
-	ProfileName           *string                           `mapstructure:"profile" required:"false" cty:"profile"`
-	RawRegion             *string                           `mapstructure:"region" required:"true" cty:"region"`
-	SecretKey             *string                           `mapstructure:"secret_key" required:"true" cty:"secret_key"`
-	SkipValidation        *bool                             `mapstructure:"skip_region_validation" required:"false" cty:"skip_region_validation"`
-	SkipMetadataApiCheck  *bool                             `mapstructure:"skip_metadata_api_check" cty:"skip_metadata_api_check"`
-	SkipCredsValidation   *bool                             `mapstructure:"skip_credential_validation" cty:"skip_credential_validation"`
-	Token                 *string                           `mapstructure:"token" required:"false" cty:"token"`
-	VaultAWSEngine        *common.FlatVaultAWSEngineOptions `mapstructure:"vault_aws_engine" required:"false" cty:"vault_aws_engine"`
-	PollingConfig         *common.FlatAWSPollingConfig      `mapstructure:"aws_polling" required:"false" cty:"aws_polling"`
-	Identifier            *string                           `mapstructure:"identifier" cty:"identifier"`
-	KeepReleases          *int                              `mapstructure:"keep_releases" cty:"keep_releases"`
-	KeepDays              *int                              `mapstructure:"keep_days" cty:"keep_days"`
-	Regions               []string                          `mapstructure:"regions" cty:"regions"`
-	DryRun                *bool                             `mapstructure:"dry_run" cty:"dry_run"`
+	PackerBuildName      *string           `mapstructure:"packer_build_name" cty:"packer_build_name"`
+	PackerBuilderType    *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type"`
+	PackerDebug          *bool             `mapstructure:"packer_debug" cty:"packer_debug"`
+	PackerForce          *bool             `mapstructure:"packer_force" cty:"packer_force"`
+	PackerOnError        *string           `mapstructure:"packer_on_error" cty:"packer_on_error"`
+	PackerUserVars       map[string]string `mapstructure:"packer_user_variables" cty:"packer_user_variables"`
+	PackerSensitiveVars  []string          `mapstructure:"packer_sensitive_variables" cty:"packer_sensitive_variables"`
+	AccessKey            *string           `mapstructure:"access_key" cty:"access_key"`
+	SecretKey            *string           `mapstructure:"secret_key" cty:"secret_key"`
+	ProfileName          *string           `mapstructure:"profile" cty:"profile"`
+	Token                *string           `mapstructure:"token" cty:"token"`
+	MFACode              *string           `mapstructure:"mfa_code" cty:"mfa_code"`
+	CustomEndpointEc2    *string           `mapstructure:"custom_endpoint_ec2" cty:"custom_endpoint_ec2"`
+	SkipValidation       *bool             `mapstructure:"skip_region_validation" cty:"skip_region_validation"`
+	SkipMetadataAPICheck *bool             `mapstructure:"skip_metadata_api_check" cty:"skip_metadata_api_check"`
+	Identifier           *string           `mapstructure:"identifier" cty:"identifier"`
+	KeepReleases         *int              `mapstructure:"keep_releases" cty:"keep_releases"`
+	KeepDays             *int              `mapstructure:"keep_days" cty:"keep_days"`
+	Regions              []string          `mapstructure:"regions" cty:"regions"`
+	DryRun               *bool             `mapstructure:"dry_run" cty:"dry_run"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -53,35 +43,26 @@ func (*Config) FlatMapstructure() interface{ HCL2Spec() map[string]hcldec.Spec }
 // The decoded values from this spec will then be applied to a FlatConfig.
 func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
-		"packer_build_name":             &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
-		"packer_builder_type":           &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
-		"packer_debug":                  &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
-		"packer_force":                  &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
-		"packer_on_error":               &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},
-		"packer_user_variables":         &hcldec.BlockAttrsSpec{TypeName: "packer_user_variables", ElementType: cty.String, Required: false},
-		"packer_sensitive_variables":    &hcldec.AttrSpec{Name: "packer_sensitive_variables", Type: cty.List(cty.String), Required: false},
-		"access_key":                    &hcldec.AttrSpec{Name: "access_key", Type: cty.String, Required: false},
-		"assume_role":                   &hcldec.BlockSpec{TypeName: "assume_role", Nested: hcldec.ObjectSpec((*common.FlatAssumeRoleConfig)(nil).HCL2Spec())},
-		"custom_endpoint_ec2":           &hcldec.AttrSpec{Name: "custom_endpoint_ec2", Type: cty.String, Required: false},
-		"shared_credentials_file":       &hcldec.AttrSpec{Name: "shared_credentials_file", Type: cty.String, Required: false},
-		"decode_authorization_messages": &hcldec.AttrSpec{Name: "decode_authorization_messages", Type: cty.Bool, Required: false},
-		"insecure_skip_tls_verify":      &hcldec.AttrSpec{Name: "insecure_skip_tls_verify", Type: cty.Bool, Required: false},
-		"max_retries":                   &hcldec.AttrSpec{Name: "max_retries", Type: cty.Number, Required: false},
-		"mfa_code":                      &hcldec.AttrSpec{Name: "mfa_code", Type: cty.String, Required: false},
-		"profile":                       &hcldec.AttrSpec{Name: "profile", Type: cty.String, Required: false},
-		"region":                        &hcldec.AttrSpec{Name: "region", Type: cty.String, Required: false},
-		"secret_key":                    &hcldec.AttrSpec{Name: "secret_key", Type: cty.String, Required: false},
-		"skip_region_validation":        &hcldec.AttrSpec{Name: "skip_region_validation", Type: cty.Bool, Required: false},
-		"skip_metadata_api_check":       &hcldec.AttrSpec{Name: "skip_metadata_api_check", Type: cty.Bool, Required: false},
-		"skip_credential_validation":    &hcldec.AttrSpec{Name: "skip_credential_validation", Type: cty.Bool, Required: false},
-		"token":                         &hcldec.AttrSpec{Name: "token", Type: cty.String, Required: false},
-		"vault_aws_engine":              &hcldec.BlockSpec{TypeName: "vault_aws_engine", Nested: hcldec.ObjectSpec((*common.FlatVaultAWSEngineOptions)(nil).HCL2Spec())},
-		"aws_polling":                   &hcldec.BlockSpec{TypeName: "aws_polling", Nested: hcldec.ObjectSpec((*common.FlatAWSPollingConfig)(nil).HCL2Spec())},
-		"identifier":                    &hcldec.AttrSpec{Name: "identifier", Type: cty.String, Required: false},
-		"keep_releases":                 &hcldec.AttrSpec{Name: "keep_releases", Type: cty.Number, Required: false},
-		"keep_days":                     &hcldec.AttrSpec{Name: "keep_days", Type: cty.Number, Required: false},
-		"regions":                       &hcldec.AttrSpec{Name: "regions", Type: cty.List(cty.String), Required: false},
-		"dry_run":                       &hcldec.AttrSpec{Name: "dry_run", Type: cty.Bool, Required: false},
+		"packer_build_name":          &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
+		"packer_builder_type":        &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_debug":               &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
+		"packer_force":               &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
+		"packer_on_error":            &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},
+		"packer_user_variables":      &hcldec.BlockAttrsSpec{TypeName: "packer_user_variables", ElementType: cty.String, Required: false},
+		"packer_sensitive_variables": &hcldec.AttrSpec{Name: "packer_sensitive_variables", Type: cty.List(cty.String), Required: false},
+		"access_key":                 &hcldec.AttrSpec{Name: "access_key", Type: cty.String, Required: false},
+		"secret_key":                 &hcldec.AttrSpec{Name: "secret_key", Type: cty.String, Required: false},
+		"profile":                    &hcldec.AttrSpec{Name: "profile", Type: cty.String, Required: false},
+		"token":                      &hcldec.AttrSpec{Name: "token", Type: cty.String, Required: false},
+		"mfa_code":                   &hcldec.AttrSpec{Name: "mfa_code", Type: cty.String, Required: false},
+		"custom_endpoint_ec2":        &hcldec.AttrSpec{Name: "custom_endpoint_ec2", Type: cty.String, Required: false},
+		"skip_region_validation":     &hcldec.AttrSpec{Name: "skip_region_validation", Type: cty.Bool, Required: false},
+		"skip_metadata_api_check":    &hcldec.AttrSpec{Name: "skip_metadata_api_check", Type: cty.Bool, Required: false},
+		"identifier":                 &hcldec.AttrSpec{Name: "identifier", Type: cty.String, Required: false},
+		"keep_releases":              &hcldec.AttrSpec{Name: "keep_releases", Type: cty.Number, Required: false},
+		"keep_days":                  &hcldec.AttrSpec{Name: "keep_days", Type: cty.Number, Required: false},
+		"regions":                    &hcldec.AttrSpec{Name: "regions", Type: cty.List(cty.String), Required: false},
+		"dry_run":                    &hcldec.AttrSpec{Name: "dry_run", Type: cty.Bool, Required: false},
 	}
 	return s
 }

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,8 @@ require (
 	github.com/aws/aws-sdk-go v1.35.9
 	github.com/dylanmei/winrmtest v0.0.0-20190225150635-99b7fe2fddf1 // indirect
 	github.com/golang/mock v1.4.4
+	github.com/hashicorp/aws-sdk-go-base v0.6.0
+	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/hashicorp/hcl/v2 v2.8.2
 	github.com/hashicorp/packer v1.6.4
 	github.com/zclconf/go-cty v1.7.1

--- a/post-processor.go
+++ b/post-processor.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/hashicorp/hcl/v2/hcldec"
-	awscommon "github.com/hashicorp/packer/builder/amazon/common"
 	"github.com/hashicorp/packer/helper/config"
 	"github.com/hashicorp/packer/packer"
 	"github.com/hashicorp/packer/template/interpolate"
@@ -31,7 +30,6 @@ func (p *PostProcessor) ConfigSpec() hcldec.ObjectSpec {
 
 // Configure generates post-processor's configuration
 func (p *PostProcessor) Configure(raws ...interface{}) error {
-	p.config.ctx.Funcs = awscommon.TemplateFuncs
 	err := config.Decode(&p.config, &config.DecodeOpts{
 		Interpolate:        true,
 		InterpolateContext: &p.config.ctx,

--- a/post-processor_test.go
+++ b/post-processor_test.go
@@ -51,7 +51,6 @@ func TestPostProcessor_Configure_validConfigWithKeepDays(t *testing.T) {
 func TestPostProcessor_Configure_missingRegions(t *testing.T) {
 	p := new(PostProcessor)
 	err := p.Configure(map[string]interface{}{
-		"region":        "us-east-1",
 		"identifier":    "packer-example",
 		"keep_releases": 3,
 	})


### PR DESCRIPTION
As the first step of upgrading to Packer v1.7, remove the AWS builder dependency (`github.com/hashicorp/packer/builder/amazon/common`) from the post-processor.

Due to this change, I have ported some code equivalent to [Packer's AccessConfig](https://github.com/hashicorp/packer/blob/v1.6.4/builder/amazon/common/access_config.go). Since Packer is distributed under the MPL license, this plugin also follows the license, which will be done in another pull request.

This change also includes some minor changes:

- `clean_resource_name` function support was removed from the post-processor attributes
- Undocumented AWS access config attributes were removed.
  - `assume_role`
  - `shared_credentials_file`
  - `decode_authorization_messages`
  - `insecure_skip_tls_verify`
  - `max_retries`
  - `region`
  - `skip_credential_validation`
  - `vault_aws_engine`
  - `aws_polling`