### PR TITLE
Make the plugin multi component plugin

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,13 +1,34 @@
 package main
 
-import "github.com/hashicorp/packer-plugin-sdk/plugin"
+import (
+	"fmt"
+	"os"
+
+	"github.com/hashicorp/packer-plugin-sdk/plugin"
+	"github.com/hashicorp/packer-plugin-sdk/version"
+)
+
+var (
+	// Version is the main version number that is being run at the moment.
+	Version = "0.9.0"
+
+	// VersionPrerelease is A pre-release marker for the Version. If this is ""
+	// (empty string) then it means that it is a final release. Otherwise, this
+	// is a pre-release such as "dev" (in development), "beta", "rc1", etc.
+	VersionPrerelease = "dev"
+
+	// PluginVersion is used by the plugin set to allow Packer to recognize
+	// what version this plugin is.
+	PluginVersion = version.InitializePluginVersion(Version, VersionPrerelease)
+)
 
 func main() {
-	server, err := plugin.Server()
+	pps := plugin.NewSet()
+	pps.RegisterPostProcessor(plugin.DEFAULT_NAME, new(PostProcessor))
+	pps.SetVersion(PluginVersion)
+	err := pps.Run()
 	if err != nil {
-		panic(err)
+		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(1)
 	}
-
-	server.RegisterPostProcessor(new(PostProcessor))
-	server.Serve()
 }

--- a/post-processor.go
+++ b/post-processor.go
@@ -31,6 +31,7 @@ func (p *PostProcessor) ConfigSpec() hcldec.ObjectSpec {
 // Configure generates post-processor's configuration
 func (p *PostProcessor) Configure(raws ...interface{}) error {
 	err := config.Decode(&p.config, &config.DecodeOpts{
+		PluginType:         "packer.post-processor.amazon-ami-management",
 		Interpolate:        true,
 		InterpolateContext: &p.config.ctx,
 		InterpolateFilter: &interpolate.RenderFilter{


### PR DESCRIPTION
This PR migrate the deprecated "Single Component Plugin" to the "Multi Component Plugin". See https://www.packer.io/guides/1.7-plugin-upgrade#how-to-upgrade-the-plugin

Due to this change, you can install the post-processor via `packer init` command automatically.

However, this change needs to rename the repository name to satisfy `packer-plugin-*` naming convention. This change will be made at releasing the next version.