### PR TITLE
Change project settings for multi component plugin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,5 +33,5 @@ jobs:
     - name: Upload Artifact
       uses: actions/upload-artifact@master
       with:
-        name: packer-post-processor-amazon-ami-management
-        path: packer-post-processor-amazon-ami-management
+        name: packer-plugin-amazon-ami-management
+        path: packer-plugin-amazon-ami-management

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,14 @@ jobs:
       uses: actions/setup-go@v2.1.3
       with:
         version: 1.15
+    - name: Describe plugin
+      id: plugin_describe
+      run: echo "::set-output name=api_version::$(go run . describe | jq -r '.api_version')"
     - name: Run GoReleaser
+      uses: goreleaser/goreleaser-action@v2
+      with:
+        version: latest
+        args: release --rm-dist
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        VERSION: v0.143.0
-      run: curl -sL https://git.io/goreleaser | bash
+        API_VERSION: ${{ steps.plugin_describe.outputs.api_version }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,33 +1,55 @@
 env:
   - CGO_ENABLED=0
-before:
-  hooks:
-    - go mod download
 builds:
-  - goos:
+  # A separated build to run the packer-plugins-check only once for a linux_amd64 binary
+  -
+    id: plugin-check
+    mod_timestamp: '{{ .CommitTimestamp }}'
+    hooks:
+      post:
+        # This will check plugin compatibility against latest version of Packer
+        - cmd: |
+            go install github.com/hashicorp/packer/cmd/packer-plugins-check &&
+            packer-plugins-check -load={{ .Name }}
+          dir: "{{ dir .Path}}"
+    flags:
+      - -trimpath #removes all file system paths from the compiled executable
+    ldflags:
+      - '-s -w -X main.Version={{.Version}} -X main.VersionPrerelease= '
+    goos:
+      - linux
+    goarch:
+      - amd64
+    binary: '{{ .ProjectName }}_v{{ .Version }}_{{ .Env.API_VERSION }}_{{ .Os }}_{{ .Arch }}'
+  - 
+    mod_timestamp: '{{ .CommitTimestamp }}'
+    flags:
+      - -trimpath #removes all file system paths from the compiled executable
+    ldflags:
+      - '-s -w -X main.version={{.Version}} -X main.VersionPrerelease= '
+    goos:
+      - freebsd
+      - windows
       - linux
       - darwin
-      - freebsd
-      - netbsd
-      - openbsd
-      - windows
     goarch:
-      - 386
       - amd64
+      - '386'
       - arm
+      - arm64
+    ignore:
+      - goos: darwin
+        goarch: '386'
+      - goos: linux
+        goarch: amd64
+    binary: '{{ .ProjectName }}_v{{ .Version }}_{{ .Env.API_VERSION }}_{{ .Os }}_{{ .Arch }}'
 archives:
-  - id: zip
-    format: zip
-    files:
-      - LICENSE
+- format: zip
+  name_template: '{{ .ProjectName }}_v{{ .Version }}_{{ .Env.API_VERSION }}_{{ .Os }}_{{ .Arch }}'
+checksum:
+  name_template: '{{ .ProjectName }}_v{{ .Version }}_SHA256SUMS'
+  algorithm: sha256
+release:
+  draft: true
 changelog:
   skip: true
-checksum:
-  name_template: 'checksums.txt'
-release:
-  github:
-    owner: wata727
-    name: packer-post-processor-amazon-ami-management
-  draft: true
-snapshot:
-  name_template: "{{ .Tag }}-dev"

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,6 @@ build: test
 
 install: build
 	mkdir -p ~/.packer.d/plugins
-	install ./packer-post-processor-amazon-ami-management ~/.packer.d/plugins/
+	mv ./packer-plugin-amazon-ami-management ~/.packer.d/plugins/
 
 .PHONY: default test build install

--- a/README.md
+++ b/README.md
@@ -1,64 +1,31 @@
-# packer-post-processor-amazon-ami-management
-[![Build Status](https://github.com/wata727/packer-post-processor-amazon-ami-management/workflows/build/badge.svg?branch=master)](https://github.com/wata727/packer-post-processor-amazon-ami-management/actions)
-[![GitHub release](https://img.shields.io/github/release/wata727/packer-post-processor-amazon-ami-management.svg)](https://github.com/wata727/packer-post-processor-amazon-ami-management/releases/latest)
-[![MIT License](http://img.shields.io/badge/license-MIT-blue.svg?style=flat)](LICENSE)
+# packer-plugin-amazon-ami-management
+[![Build Status](https://github.com/wata727/packer-plugin-amazon-ami-management/workflows/build/badge.svg?branch=master)](https://github.com/wata727/packer-plugin-amazon-ami-management/actions)
+[![GitHub release](https://img.shields.io/github/release/wata727/packer-plugin-amazon-ami-management.svg)](https://github.com/wata727/packer-plugin-amazon-ami-management/releases/latest)
+[![License: MPL 2.0](https://img.shields.io/badge/License-MPL%202.0-blue.svg)](LICENSE)
 
-Packer post-processor plugin for AMI management
+Packer post-processor plugin for Amazon AMI management
 
 ## Description
-This post-processor cleanups old AMIs and EBS snapshots using `amazon-ebs` builder's access configuration after baking a new AMI.
+This post-processor cleanups old AMIs and EBS snapshots after baking a new AMI.
 
 ## Installation
-Packer supports plugin system. Please read the following documentation:
+Packer >= v1.7.0 supports third-party plugin installation by `init` command. You can install the plugin automatically after adding the `required_plugin` block.
 
-https://www.packer.io/docs/extend/plugins.html
-
-You can download binary built for your architecture from [latest releases](https://github.com/wata727/packer-post-processor-amazon-ami-management/releases/latest).
-
-For example, to install v0.9.0 for 64bit OSX
-
-For Linux based OS, you can use the install_linux.sh to automate the installation process
-
-```sh
-mkdir -p ~/.packer.d/plugins
-wget https://github.com/wata727/packer-post-processor-amazon-ami-management/releases/download/v0.9.0/packer-post-processor-amazon-ami-management_0.9.0_darwin_amd64.zip -P /tmp/
-cd ~/.packer.d/plugins
-unzip -j /tmp/packer-post-processor-amazon-ami-management_0.9.0_darwin_amd64.zip -d ~/.packer.d/plugins
-```
-
-## Usage
-The following example is a template to keep only the latest 3 AMIs.
-
-```json
-{
-  "builders": [{
-    "type": "amazon-ebs",
-    "region": "us-east-1",
-    "source_ami": "ami-6869aa05",
-    "instance_type": "t2.micro",
-    "ssh_username": "ec2-user",
-    "ssh_pty": "true",
-    "ami_name": "packer-example {{timestamp}}",
-    "tags": {
-        "Amazon_AMI_Management_Identifier": "packer-example"
+```hcl
+packer {
+  required_plugins {
+    amazon_ami_management = {
+      version = ">= 1.0.0"
+      source = "github.com/wata727/amazon-ami-management"
     }
-  }],
-  "provisioners":[{
-    "type": "shell",
-    "inline": [
-      "echo 'running...'"
-    ]
-  }],
-  "post-processors":[{
-    "type": "amazon-ami-management",
-    "regions": ["us-east-1"],
-    "identifier": "packer-example",
-    "keep_releases": "3"
-  }]
+  }
 }
 ```
 
-The following is example in HCL2 (after Packer v1.5.0):
+See the [Packer documentation](https://www.packer.io/docs/plugins#installing-plugins) for more details.
+
+## Usage
+The following example is a template to keep only the latest 3 AMIs.
 
 ```hcl
 source "amazon-ebs" "example" {

--- a/access_config.go
+++ b/access_config.go
@@ -127,7 +127,7 @@ func IsAWSErr(err error, code string, message string) bool {
 // NewNoValidCredentialSourcesError returns user-friendly errors for authentication failed.
 func (c *AccessConfig) NewNoValidCredentialSourcesError(err error) error {
 	return fmt.Errorf("No valid credential sources found for amazon-ami-management post processor. "+
-		"Please see https://github.com/wata727/packer-post-processor-amazon-ami-management "+
+		"Please see https://github.com/wata727/packer-plugin-amazon-ami-management "+
 		"for more information on providing credentials for the post processor. "+
 		"Error: %w", err)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/wata727/packer-post-processor-amazon-ami-management
+module github.com/wata727/packer-plugin-amazon-ami-management
 
 go 1.15
 


### PR DESCRIPTION
Change project settings, including the repository name, for multi component plugin.

The major changes are:

- Rename to `packer-plugin-amazon-ami-management` from `packer-post-processor-amazon-ami-management`.
- Ends pre-built binary support for some OS architectures.
  - This is due to follow the recently released [packer-plugin-scaffolding's .goreleaser.yml](https://github.com/hashicorp/packer-plugin-scaffolding/blob/5a92820fb5498c82f72a89fb93fa620fddb0bae5/.goreleaser.yml).
  - Added
    - freebsd_arm64
    - linux_arm64
  - Removed
    - netbsd
    - openbsd